### PR TITLE
Bug fix: Admins extending NestedModelAdmin are not picking up custom for...

### DIFF
--- a/nested_inlines/admin.py
+++ b/nested_inlines/admin.py
@@ -17,11 +17,16 @@ class NestedModelAdmin(ModelAdmin):
     class Media:
         css = {'all': ('admin/css/nested.css',)}
         js = ('admin/js/nested.js',)
-        
+
     def get_form(self, request, obj=None, **kwargs):
+        from django.forms.models import ModelForm
+        if self.form == ModelForm:
+            form = BaseNestedModelForm
+        else:
+            form = self.form
         return super(NestedModelAdmin, self).get_form(
-            request, obj, form=BaseNestedModelForm, **kwargs)
-        
+            request, obj, form=form, **kwargs)
+
     def get_inline_instances(self, request, obj=None):
         inline_instances = []
         for inline_class in self.inlines:
@@ -36,13 +41,13 @@ class NestedModelAdmin(ModelAdmin):
             inline_instances.append(inline)
 
         return inline_instances
-    
+
     def save_formset(self, request, form, formset, change):
         """
         Given an inline formset save it to the database.
         """
         formset.save()
-        
+
         #iterate through the nested formsets and save them
         #skip formsets, where the parent is marked for deletion
         deleted_forms = formset.deleted_forms
@@ -50,7 +55,7 @@ class NestedModelAdmin(ModelAdmin):
             if hasattr(form, 'nested_formsets') and form not in deleted_forms:
                 for nested_formset in form.nested_formsets:
                     self.save_formset(request, form, nested_formset, change)
-                    
+
     def add_nested_inline_formsets(self, request, inline, formset, depth=0):
         if depth > 5:
             raise Exception("Maximum nesting depth reached (5)")
@@ -59,7 +64,7 @@ class NestedModelAdmin(ModelAdmin):
             for nested_inline in inline.get_inline_instances(request):
                 InlineFormSet = nested_inline.get_formset(request, form.instance)
                 prefix = "%s-%s" % (form.prefix, InlineFormSet.get_default_prefix())
-                
+
                 #because of form nesting with extra=0 it might happen, that the post data doesn't include values for the formset.
                 #This would lead to a Exception, because the ManagementForm construction fails. So we check if there is data available, and otherwise create an empty form
                 keys = request.POST.keys()
@@ -75,7 +80,7 @@ class NestedModelAdmin(ModelAdmin):
                 if nested_inline.inlines:
                     self.add_nested_inline_formsets(request, nested_inline, nested_formset, depth=depth+1)
             form.nested_formsets = nested_formsets
-            
+
     def wrap_nested_inline_formsets(self, request, inline, formset):
         """wraps each formset in a helpers.InlineAdminFormset.
         @TODO someone with more inside knowledge should write done why this is done
@@ -86,7 +91,7 @@ class NestedModelAdmin(ModelAdmin):
                 return media + extra_media
             else:
                 return extra_media
-                        
+
         for form in formset.forms:
             wrapped_nested_formsets = []
             for nested_inline, nested_formset in zip(inline.get_inline_instances(request), form.nested_formsets):
@@ -105,7 +110,7 @@ class NestedModelAdmin(ModelAdmin):
                     media = get_media(self.wrap_nested_inline_formsets(request, nested_inline, nested_formset))
             form.nested_formsets = wrapped_nested_formsets
         return media
-    
+
     def all_valid_with_nesting(self, formsets):
         """Recursively validate all nested formsets
         """
@@ -119,7 +124,7 @@ class NestedModelAdmin(ModelAdmin):
                     if not self.all_valid_with_nesting(form.nested_formsets):
                         return False
         return True
-    
+
     @csrf_protect_m
     @transaction.commit_on_success
     def add_view(self, request, form_url='', extra_context=None):
@@ -318,7 +323,7 @@ class NestedInlineModelAdmin(InlineModelAdmin):
     def get_form(self, request, obj=None, **kwargs):
         return super(NestedModelAdmin, self).get_form(
             request, obj, form=BaseNestedModelForm, **kwargs)
-    
+
     def get_inline_instances(self, request, obj=None):
         inline_instances = []
         for inline_class in self.inlines:
@@ -333,13 +338,13 @@ class NestedInlineModelAdmin(InlineModelAdmin):
             inline_instances.append(inline)
 
         return inline_instances
-    
+
     def get_formsets(self, request, obj=None):
         for inline in self.get_inline_instances(request):
             yield inline.get_formset(request, obj)
 
 class NestedStackedInline(NestedInlineModelAdmin):
     template = 'admin/edit_inline/stacked.html'
-    
+
 class NestedTabularInline(NestedInlineModelAdmin):
     template = 'admin/edit_inline/tabular.html'


### PR DESCRIPTION
I noticed that subclasses of NestedModelAdmin were ignoring custom forms which had been set using 'form = MyForm' in the class definition. This change now allows custom forms to be used.
